### PR TITLE
Removendo métodos de retrieve de Report

### DIFF
--- a/server/routes/reportRouter.js
+++ b/server/routes/reportRouter.js
@@ -26,29 +26,4 @@ router.post('/', async (req, res) => {
 
 });
 
-/**
- * GET consulta todos os reports
- */
-router.get('/', async (req, res) => {
-    try {
-      const data = await ReportService.retrieveReports();
-      res.status(200).json(data);
-    } catch(err) {
-      res.status(400).json(err.message);
-    }
-});
-
-/**
- * GET consulta um report especifico
- */
-router.get('/:id', async (req, res) => {
-    const id = req.params.id;
-    try {
-      const data = await ReportService.retrieveReport(id);
-      res.status(200).json(data);
-    } catch(err) {
-      res.status(400).json(err.message);
-    }
-});
-
 module.exports = router;

--- a/server/service/ReportService.js
+++ b/server/service/ReportService.js
@@ -9,27 +9,6 @@ db_config();
  * @author Team Hipster
  */
 export class ReportService{
-
-    /**
-     * Consulta um Report dado um id.
-     *
-     * @param   {String}  id do report para recuperação.
-     * @returns {Promise}  Promise resolvida com o objeto Report
-     * da forma que o mongo retorna.
-     */
-    static retrieveReport(id) {
-      return Report.findOne({_id: id}).exec();
-    }
-  
-     /**
-     * Consulta todos os Reports.
-     *
-     * @returns {Promise}  Promise resolvida com uma lista de objetos Report
-     * da forma que o mongo retorna.
-     */
-    static retrieveReports() {
-      return Report.find({}).sort({reportDate: -1}).exec();
-    }
   
     /**
      * Cadastra um Report
@@ -43,4 +22,4 @@ export class ReportService{
       return reportMongoose.save();
     }
       
-  }
+}

--- a/src/app/services/report.service.ts
+++ b/src/app/services/report.service.ts
@@ -14,18 +14,6 @@ export class ReportService {
     this.serverHost = globalService.getServerHost();
   }
 
-  public getReport(id) {
-    return this.http.get(this.serverHost + 'v1/report/' + id, {
-      headers: this.headers
-    });
-  }
-
-  public getAllReports() {
-    return this.http.get(this.serverHost + 'v1/report', {
-      headers: this.headers
-    });
-  }
-
   public saveReport(report) {
     return this.http.post(this.serverHost + 'v1/report', JSON.stringify(report), {
       headers: this.headers


### PR DESCRIPTION
- Remoção dos métodos e rotas relacionados à consulta de reports. Apenas cadastrar reports é possível, e os mesmos são enviados pra o e-mail da empresa.